### PR TITLE
explicitly install httparty at ~> 0.11.0

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,8 +17,11 @@
 # limitations under the License.
 #
 
-hipchat = chef_gem 'hipchat' do
+chef_gem 'httparty' do
+  version '~> 0.11.0'
   action :nothing
-end
+end.run_action(:install)
 
-hipchat.run_action(:install)
+chef_gem 'hipchat' do
+  action :nothing
+end.run_action(:install)


### PR DESCRIPTION
httparty 0.12.0 changes json version dependencies, which now conflict with chef
