### PR TITLE
custom server url support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,2 @@
-default['hipchat']['hipchat_version'] = '0.12.0'
+default['hipchat']['hipchat_version'] = '1.2.0'
 default['hipchat']['httparty_version'] = '0.11.0'

--- a/attributes/handler.rb
+++ b/attributes/handler.rb
@@ -1,4 +1,5 @@
 # values are required for token and room attrs
+default['hipchat']['handler']['server'] = 'https://api.hipchat.com'
 default['hipchat']['handler']['token'] = nil
 default['hipchat']['handler']['room'] = nil
 default['hipchat']['handler']['enabled'] = false

--- a/files/default/handler.rb
+++ b/files/default/handler.rb
@@ -41,6 +41,7 @@ module HipChat
       @room_name = room_name
       @options = options
 
+      @options[:server_url] = 'https://api.hipchat.com' if @options[:server_url].nil?
       @options[:name] = 'Chef' if @options[:name].nil?
       @options[:notify_users] = false if @options[:notify_users].nil?
       @options[:color] = 'red' if @options[:color].nil?
@@ -49,7 +50,7 @@ module HipChat
     def report
       msg = "Failure on #{node.name}: #{run_status.formatted_exception}"
 
-      client = HipChat::Client.new(@api_token)
+      client = HipChat::Client.new(@api_token, :api_version => 'v2', :server_url => @options[:server_url])
       client[@room_name].send(
         @options[:name],
         msg,

--- a/providers/msg.rb
+++ b/providers/msg.rb
@@ -1,7 +1,7 @@
 action :speak do
   require 'hipchat'
   begin
-    client = HipChat::Client.new(@new_resource.token, :api_version => 'v2')
+    client = HipChat::Client.new(@new_resource.token, :api_version => 'v2', :server_url => @new_resource.server)
 
     message = @new_resource.message || @new_resource.name
 

--- a/recipes/handler.rb
+++ b/recipes/handler.rb
@@ -39,6 +39,7 @@ end.run_action(:create)
 
 handler = node['hipchat']['handler']
 handler_options = {
+  :server_url => handler['server'],
   :name => handler['name'],
   :notify_users => handler['notify_users'],
   :color => handler['color']

--- a/resources/msg.rb
+++ b/resources/msg.rb
@@ -5,6 +5,7 @@ end
 
 actions :speak
 
+attribute :server, :kind_of => String, :default => 'https://api.hipchat.com'
 attribute :nickname, :kind_of => String, :required => true
 attribute :token, :kind_of => String, :required => true
 attribute :room, :kind_of => String, :required => true


### PR DESCRIPTION
Added functionality for private hosted hipchat. If no url is set the default of https://api.hipchat.com is still used
