### PR TITLE
Added support for self-hosted HipChat Server via server_url attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Should work on any platform where Chef runs. Tested on Ubuntu.
 * `notify` - toggles whether or not users in the room should be notified by this message (defaults to true).
 * `color` - sets the color of the message in HipChat. Supported colors include: yellow, red, green, purple, or random (defaults to yellow).
 * `failure_ok` - toggles whether or not to catch the exception if an error is encountered connecting to HipChat (defaults to true).
+* `server_url` - Specify if you have self-hosted HipChat Server
 
 ## Usage example
 
@@ -41,6 +42,11 @@ Should work on any platform where Chef runs. Tested on Ubuntu.
         end
 
 ## Changes
+
+### 0.4.0
+* Added support for self-hosted HipChat Server via server_url attribute
+* Bolded the hostname in handler exception messages
+* Changed HipChat Ruby gem to 1.3.0
 
 ### 0.2.0
 * Added test-kitchen. Export HIPCHAT_TEST_ROOM and HIPCHAT_TEST_TOKEN env vars when running test-kitchen

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,3 @@
-default['hipchat']['hipchat_version'] = '0.12.0'
-default['hipchat']['httparty_version'] = '0.11.0'
+default['hipchat']['hipchat_version'] = '1.3.0'
+default['hipchat']['httparty_version'] = '0.13.1'
+default['hipchat']['server_url'] = nil

--- a/files/default/handler.rb
+++ b/files/default/handler.rb
@@ -47,9 +47,14 @@ module HipChat
     end
 
     def report
-      msg = "Failure on #{node.name}: #{run_status.formatted_exception}"
+      msg = "Failure on <strong>#{node.name}</strong>: #{run_status.formatted_exception}"
 
-      client = HipChat::Client.new(@api_token)
+      if @options[:server_url]
+        client = HipChat::Client.new(@api_token, :api_version => 'v2', :server_url => @options[:server_url])
+      else
+        client = HipChat::Client.new(@api_token)
+      end
+      
       client[@room_name].send(
         @options[:name],
         msg,

--- a/providers/msg.rb
+++ b/providers/msg.rb
@@ -1,8 +1,12 @@
 action :speak do
   require 'hipchat'
   begin
-    client = HipChat::Client.new(@new_resource.token)
-
+    if node['hipchat']['server_url']
+      client = HipChat::Client.new(@new_resource.token, :api_version => 'v2', :server_url => node['hipchat']['server_url'])
+    else
+      client = HipChat::Client.new(@new_resource.token)
+    end
+    
     message = @new_resource.message || @new_resource.name
 
     client[@new_resource.room].send(@new_resource.nickname,

--- a/recipes/handler.rb
+++ b/recipes/handler.rb
@@ -41,7 +41,8 @@ handler = node['hipchat']['handler']
 handler_options = {
   :name => handler['name'],
   :notify_users => handler['notify_users'],
-  :color => handler['color']
+  :color => handler['color'],
+  :server_url => node['hipchat']['server_url']
 }
 
 chef_handler 'HipChat::NotifyRoom' do


### PR DESCRIPTION
https://github.com/cwjohnston/chef-hipchat/issues/11

Note I had to bump the hipchat gem to a much newer version.  I also bumped httparty, but this may not have been necessary. 
